### PR TITLE
use older version of ThreeBodyDecays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,6 +28,7 @@ RecipesBase = "1.3.4"
 StaticArrays = "1.7.0"
 ThreadsX = "0.1.11"
 YAML = "0.4.9"
+ThreeBodyDecays = 0.9.0"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
Three seems to be breaking introduced at `ThreeBodyDecays.jl` at v.0.10 when the `ThreeBodyDecay` is implemented.
This PR limits the used version to the old release trying to check if it fixes the problem